### PR TITLE
Change direction of 3v3 pin

### DIFF
--- a/RP-Pico Libraries/MCU_RaspberryPi_and_Boards.kicad_sym
+++ b/RP-Pico Libraries/MCU_RaspberryPi_and_Boards.kicad_sym
@@ -148,7 +148,7 @@
         (name "3V3_EN" (effects (font (size 1.27 1.27))))
         (number "37" (effects (font (size 1.27 1.27))))
       )
-      (pin bidirectional line (at 17.78 19.05 180) (length 2.54)
+      (pin power_in line (at 17.78 19.05 180) (length 2.54)
         (name "GND" (effects (font (size 1.27 1.27))))
         (number "38" (effects (font (size 1.27 1.27))))
       )

--- a/RP-Pico Libraries/MCU_RaspberryPi_and_Boards.kicad_sym
+++ b/RP-Pico Libraries/MCU_RaspberryPi_and_Boards.kicad_sym
@@ -136,7 +136,7 @@
         (name "GPIO28_ADC2" (effects (font (size 1.27 1.27))))
         (number "34" (effects (font (size 1.27 1.27))))
       )
-      (pin power_in line (at 17.78 11.43 180) (length 2.54)
+      (pin input line (at 17.78 11.43 180) (length 2.54)
         (name "ADC_VREF" (effects (font (size 1.27 1.27))))
         (number "35" (effects (font (size 1.27 1.27))))
       )

--- a/RP-Pico Libraries/MCU_RaspberryPi_and_Boards.kicad_sym
+++ b/RP-Pico Libraries/MCU_RaspberryPi_and_Boards.kicad_sym
@@ -140,7 +140,7 @@
         (name "ADC_VREF" (effects (font (size 1.27 1.27))))
         (number "35" (effects (font (size 1.27 1.27))))
       )
-      (pin power_in line (at 17.78 13.97 180) (length 2.54)
+      (pin power_out line (at 17.78 13.97 180) (length 2.54)
         (name "3V3" (effects (font (size 1.27 1.27))))
         (number "36" (effects (font (size 1.27 1.27))))
       )


### PR DESCRIPTION
The 3.3 volt pin on the Pi is an output. This fixes that so that the ERC passes when I'm using this pin to power subcomponents.